### PR TITLE
Replaced live server with webpack dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "build": "webpack",
-    "start": "webpack && node_modules/.bin/live-server --port=8000"
+    "start": "webpack-dev-server"
   },
   "repository": {
     "type": "git",
@@ -19,8 +19,10 @@
   },
   "homepage": "https://github.com/photonstorm/phaser3-project-template#readme",
   "devDependencies": {
-    "live-server": "^1.2.0",
-    "phaser": "^3.0.0-beta.16",
+    "webpack-dev-server": "^2.11.0",
     "webpack": "^3.4.1"
+  },
+  "dependencies": {
+    "phaser": "^3.0.0-beta.16"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
 
     output: {
         path: path.resolve(__dirname, 'build'),
+        publicPath: '/build/',
         filename: 'project.bundle.js'
     },
 


### PR DESCRIPTION
This gives the user live reload for free. 

Also moved phaser to dependencies (vs devDependencies) as it's used during "run time", not just as part of the build process. 